### PR TITLE
Add color modifier for the unchecked state

### DIFF
--- a/switch.sass
+++ b/switch.sass
@@ -148,3 +148,14 @@ $switch-paddle-transition: all 0.25s ease-out !default
           + label
             &::after
               box-shadow: none
+    &.is-unchecked-#{$name}
+      + label
+        &::before
+          background: $color
+      &.is-outlined
+          + label
+            &::before
+              background-color: transparent
+              border-color: $color !important
+            &::after
+              background: $color


### PR DESCRIPTION
Hi,

Thanks for your bulma-extensions !

I added more color modifiers to the switch, to be able to define the color when the checkbox is unchecked. 

- **is-unchecked-info**
- **is-unchecked-warning**
- **is-unchecked-danger**
- ...etc


Example : 

```
<div class="field">
  <input id="switchColorSuccess" type="checkbox" name="switchColorSuccess" class="switch is-success is-unchecked-danger" checked="checked">
  <label for="switchColorSuccess">Switch success</label>
</div>
```


It was useful for me in a project because i had a lot of use cases and the *$switch-background* variable was not enough for my needs.
I open a pull request because it may help other people :-)
